### PR TITLE
Refactor serializers to support saving configurations to file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.crafty</groupId>
     <artifactId>craftycore</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.6</version>
     <packaging>jar</packaging>
 
     <name>CraftyCore</name>

--- a/src/main/java/dev/crafty/core/config/ConfigurationManager.java
+++ b/src/main/java/dev/crafty/core/config/ConfigurationManager.java
@@ -4,8 +4,6 @@ import dev.crafty.core.config.annotation.ConfigurationFile;
 import dev.crafty.core.config.annotation.ConfigValue;
 import dev.crafty.core.config.serializer.ConfigSerializer;
 import dev.crafty.core.config.serializer.SerializerRegistry;
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.Plugin;
 
@@ -31,7 +29,7 @@ import java.util.logging.Level;
 public class ConfigurationManager {
 
     private final Plugin plugin;
-    private final Map<Class<?>, SectionWrapper> configCache = new HashMap<>();
+    private final Map<Class<?>, YamlConfiguration> configCache = new HashMap<>();
     private final Map<Class<?>, File> configFiles = new HashMap<>();
     private final Map<Class<?>, Plugin> configPlugins = new HashMap<>();
 
@@ -51,7 +49,7 @@ public class ConfigurationManager {
      * @return The loaded configuration
      * @throws IllegalArgumentException If the class is not annotated with @ConfigurationFile
      */
-    public SectionWrapper loadConfig(Class<?> clazz) {
+    public YamlConfiguration loadConfig(Class<?> clazz) {
         return loadConfig(clazz, plugin);
     }
 
@@ -63,7 +61,7 @@ public class ConfigurationManager {
      * @return The loaded configuration
      * @throws IllegalArgumentException If the class is not annotated with @ConfigurationFile
      */
-    public SectionWrapper loadConfig(Class<?> clazz, Plugin plugin) {
+    public YamlConfiguration loadConfig(Class<?> clazz, Plugin plugin) {
         ConfigurationFile annotation = clazz.getAnnotation(ConfigurationFile.class);
         if (annotation == null) {
             throw new IllegalArgumentException("Class " + clazz.getName() + " is not annotated with @ConfigurationFile");
@@ -84,7 +82,7 @@ public class ConfigurationManager {
             plugin.saveResource(filePath, false);
         }
 
-        SectionWrapper config = new SectionWrapper(YamlConfiguration.loadConfiguration(configFile));
+        var config = YamlConfiguration.loadConfiguration(configFile);
         configCache.put(clazz, config);
 
         return config;
@@ -97,7 +95,7 @@ public class ConfigurationManager {
      * @return The reloaded configuration
      * @throws IllegalArgumentException If the class is not annotated with @ConfigurationFile
      */
-    public SectionWrapper reloadConfig(Class<?> clazz) {
+    public YamlConfiguration reloadConfig(Class<?> clazz) {
         ConfigurationFile annotation = clazz.getAnnotation(ConfigurationFile.class);
         if (annotation == null) {
             throw new IllegalArgumentException("Class " + clazz.getName() + " is not annotated with @ConfigurationFile");
@@ -110,8 +108,7 @@ public class ConfigurationManager {
             return loadConfig(clazz, pluginForClass);
         }
 
-        SectionWrapper config = new SectionWrapper(YamlConfiguration.loadConfiguration(configFile));
-
+        var config = YamlConfiguration.loadConfiguration(configFile);
         configCache.put(clazz, config);
 
         return config;
@@ -131,9 +128,15 @@ public class ConfigurationManager {
             throw new IllegalArgumentException("Class " + clazz.getName() + " is not annotated with @ConfigurationFile");
         }
 
-        SectionWrapper config = loadConfig(clazz, plugin);
+        YamlConfiguration configFile = loadConfig(clazz, plugin);
 
-        populateFieldsWithAnnotation(object, plugin, clazz, config);
+        populateFieldsWithAnnotation(object, plugin, clazz, new SectionWrapper(configFile));
+
+        try {
+            configFile.save(configFiles.get(clazz));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
@@ -166,9 +169,16 @@ public class ConfigurationManager {
             configPlugins.put(clazz, plugin);
         }
 
-        SectionWrapper config = reloadConfig(clazz);
+        YamlConfiguration configFile = reloadConfig(clazz);
+        var config = new SectionWrapper(configFile);
 
         populateFieldsWithAnnotation(object, plugin, clazz, config);
+
+        try {
+            configFile.save(configFiles.get(clazz));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
 
         plugin.getLogger().info("Reloaded configuration for " + clazz.getSimpleName());
     }

--- a/src/main/java/dev/crafty/core/config/ConfigurationManager.java
+++ b/src/main/java/dev/crafty/core/config/ConfigurationManager.java
@@ -132,11 +132,7 @@ public class ConfigurationManager {
 
         populateFieldsWithAnnotation(object, plugin, clazz, new SectionWrapper(configFile));
 
-        try {
-            configFile.save(configFiles.get(clazz));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        saveConfigFile(configFile, clazz);
     }
 
     /**
@@ -174,11 +170,7 @@ public class ConfigurationManager {
 
         populateFieldsWithAnnotation(object, plugin, clazz, config);
 
-        try {
-            configFile.save(configFiles.get(clazz));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        saveConfigFile(configFile, clazz);
 
         plugin.getLogger().info("Reloaded configuration for " + clazz.getSimpleName());
     }
@@ -355,6 +347,14 @@ public class ConfigurationManager {
                     throw new IllegalArgumentException("Cannot set field of type " + fieldType.getName() + " from string value", e);
                 }
             }
+        }
+    }
+
+    private void saveConfigFile(YamlConfiguration configFile, Class<?> clazz) {
+        try {
+            configFile.save(configFiles.get(clazz));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/dev/crafty/core/config/YamlConfigurationWrapper.java
+++ b/src/main/java/dev/crafty/core/config/YamlConfigurationWrapper.java
@@ -1,0 +1,16 @@
+package dev.crafty.core.config;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.jetbrains.annotations.Contract;
+
+public class YamlConfigurationWrapper extends SectionWrapper {
+
+    @Contract("null -> fail")
+    public YamlConfigurationWrapper(YamlConfiguration config) {
+        super(config);
+    }
+
+    public YamlConfiguration getYamlConfiguration() {
+        return (YamlConfiguration) super.getDelegate();
+    }
+}

--- a/src/main/java/dev/crafty/core/config/serializer/ConfigSerializer.java
+++ b/src/main/java/dev/crafty/core/config/serializer/ConfigSerializer.java
@@ -1,6 +1,7 @@
 package dev.crafty.core.config.serializer;
 
 import dev.crafty.core.config.SectionWrapper;
+import dev.crafty.core.config.YamlConfigurationWrapper;
 import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.io.File;
@@ -46,20 +47,24 @@ public interface ConfigSerializer<T> {
 
     default void save(SerializationArgs<T> args) {
         if (!args.save) return;
-        YamlConfiguration config = YamlConfiguration.loadConfiguration(args.configFile);
+        var yamlConfig = args.parent().getYamlConfiguration();
 
         try {
-            config.save(args.configFile);
+            yamlConfig.save(args.configFile);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
     record SerializationArgs<T>(
-            T value, SectionWrapper section, String path, File configFile, boolean save
+            T value, SectionWrapper section, YamlConfigurationWrapper parent, String path, File configFile, boolean save
     ) {
-        public SerializationArgs(T value, SectionWrapper section, String path, File configFile) {
-            this(value, section, path, configFile, true);
+        public SerializationArgs(T value, SectionWrapper section, YamlConfigurationWrapper parent, String path, File configFile) {
+            this(value, section, parent, path, configFile, true);
+        }
+
+        public SerializationArgs(T value, YamlConfigurationWrapper parent, String path, File configFile) {
+            this(value, parent, parent, path, configFile, true);
         }
     }
 }

--- a/src/main/java/dev/crafty/core/config/serializer/ConfigSerializer.java
+++ b/src/main/java/dev/crafty/core/config/serializer/ConfigSerializer.java
@@ -1,7 +1,10 @@
 package dev.crafty.core.config.serializer;
 
 import dev.crafty.core.config.SectionWrapper;
+import org.bukkit.configuration.file.YamlConfiguration;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Optional;
 
 /**
@@ -21,7 +24,7 @@ public interface ConfigSerializer<T> {
      * @param section The configuration section to serialize to
      * @param path The path within the section to serialize to
      */
-    void serialize(T value, SectionWrapper section, String path);
+    void serialize(T value, SectionWrapper section, String path, File configFile);
 
     /**
      * Deserialize an object from a configuration section.
@@ -41,5 +44,15 @@ public interface ConfigSerializer<T> {
 
     default <S> ConfigSerializer<S> getSerializer(Class<S> type) {
         return SerializerRegistry.getSerializer(type).orElseThrow(() -> new IllegalArgumentException("No serializer found for type " + type.getName()));
+    }
+
+    default void save(File configFile) {
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(configFile);
+
+        try {
+            config.save(configFile);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/dev/crafty/core/config/serializer/ConfigSerializer.java
+++ b/src/main/java/dev/crafty/core/config/serializer/ConfigSerializer.java
@@ -20,11 +20,9 @@ public interface ConfigSerializer<T> {
     /**
      * Serialize an object to a configuration section.
      *
-     * @param value The object to serialize
-     * @param section The configuration section to serialize to
-     * @param path The path within the section to serialize to
+     * @param args The serialization arguments
      */
-    void serialize(T value, SectionWrapper section, String path, File configFile);
+    void serialize(SerializationArgs<T> args);
 
     /**
      * Deserialize an object from a configuration section.
@@ -46,13 +44,22 @@ public interface ConfigSerializer<T> {
         return SerializerRegistry.getSerializer(type).orElseThrow(() -> new IllegalArgumentException("No serializer found for type " + type.getName()));
     }
 
-    default void save(File configFile) {
-        YamlConfiguration config = YamlConfiguration.loadConfiguration(configFile);
+    default void save(SerializationArgs<T> args) {
+        if (!args.save) return;
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(args.configFile);
 
         try {
-            config.save(configFile);
+            config.save(args.configFile);
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    record SerializationArgs<T>(
+            T value, SectionWrapper section, String path, File configFile, boolean save
+    ) {
+        public SerializationArgs(T value, SectionWrapper section, String path, File configFile) {
+            this(value, section, path, configFile, true);
         }
     }
 }

--- a/src/main/java/dev/crafty/core/config/serializer/SerializerFactory.java
+++ b/src/main/java/dev/crafty/core/config/serializer/SerializerFactory.java
@@ -1,12 +1,11 @@
 package dev.crafty.core.config.serializer;
 
 import dev.crafty.core.config.SectionWrapper;
-import org.bukkit.configuration.ConfigurationSection;
 
+import java.io.File;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 /**
  * Factory for creating serializers for common types.
@@ -32,8 +31,10 @@ public class SerializerFactory {
         
         return new ConfigSerializer<>() {
             @Override
-            public void serialize(T value, SectionWrapper section, String path) {
+            public void serialize(T value, SectionWrapper section, String path, File configFile) {
                 section.set(path, value);
+
+                save(configFile);
             }
 
             @Override
@@ -68,8 +69,10 @@ public class SerializerFactory {
         
         return new ConfigSerializer<>() {
             @Override
-            public void serialize(List<T> value, SectionWrapper section, String path) {
+            public void serialize(List<T> value, SectionWrapper section, String path, File configFile) {
                 section.set(path, value);
+
+                save(configFile);
             }
 
             @Override

--- a/src/main/java/dev/crafty/core/config/serializer/SerializerFactory.java
+++ b/src/main/java/dev/crafty/core/config/serializer/SerializerFactory.java
@@ -31,10 +31,14 @@ public class SerializerFactory {
         
         return new ConfigSerializer<>() {
             @Override
-            public void serialize(T value, SectionWrapper section, String path, File configFile) {
+            public void serialize(SerializationArgs<T> args) {
+                var section = args.section();
+                var path = args.path();
+                var value = args.value();
+                
                 section.set(path, value);
 
-                save(configFile);
+                save(args);
             }
 
             @Override
@@ -69,10 +73,14 @@ public class SerializerFactory {
         
         return new ConfigSerializer<>() {
             @Override
-            public void serialize(List<T> value, SectionWrapper section, String path, File configFile) {
+            public void serialize(SerializationArgs<List<T>> args) {
+                var section = args.section();
+                var path = args.path();
+                var value = args.value();
+                
                 section.set(path, value);
 
-                save(configFile);
+                save(args);
             }
 
             @Override

--- a/src/main/java/dev/crafty/core/config/serializer/builtin/ItemStackSerializer.java
+++ b/src/main/java/dev/crafty/core/config/serializer/builtin/ItemStackSerializer.java
@@ -19,8 +19,11 @@ import java.util.concurrent.atomic.AtomicReference;
 public class ItemStackSerializer implements ConfigSerializer<ItemStack> {
 
     @Override
-    public void serialize(ItemStack value, SectionWrapper section, String path, File configFile) {
-        // todo
+    public void serialize(SerializationArgs<ItemStack> args) {
+        var value = args.value();
+        var section = args.section();
+        var path = args.path();
+
         if (value == null) {
             section.set(path, null);
             return;
@@ -28,7 +31,7 @@ public class ItemStackSerializer implements ConfigSerializer<ItemStack> {
         
         section.set(path, value);
 
-        save(configFile);
+        save(args);
     }
 
     @Override

--- a/src/main/java/dev/crafty/core/config/serializer/builtin/ItemStackSerializer.java
+++ b/src/main/java/dev/crafty/core/config/serializer/builtin/ItemStackSerializer.java
@@ -6,6 +6,7 @@ import dev.crafty.core.util.*;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
+import java.io.File;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -18,7 +19,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class ItemStackSerializer implements ConfigSerializer<ItemStack> {
 
     @Override
-    public void serialize(ItemStack value, SectionWrapper section, String path) {
+    public void serialize(ItemStack value, SectionWrapper section, String path, File configFile) {
         // todo
         if (value == null) {
             section.set(path, null);
@@ -26,6 +27,8 @@ public class ItemStackSerializer implements ConfigSerializer<ItemStack> {
         }
         
         section.set(path, value);
+
+        save(configFile);
     }
 
     @Override

--- a/src/main/java/dev/crafty/core/geometry/serializers/Point2dSerializer.java
+++ b/src/main/java/dev/crafty/core/geometry/serializers/Point2dSerializer.java
@@ -5,6 +5,7 @@ import dev.crafty.core.config.serializer.ConfigSerializer;
 import dev.crafty.core.geometry.Point2d;
 import dev.crafty.core.util.Optionals;
 
+import java.io.File;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -13,9 +14,11 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class Point2dSerializer implements ConfigSerializer<Point2d> {
     @Override
-    public void serialize(Point2d value, SectionWrapper section, String path) {
+    public void serialize(Point2d value, SectionWrapper section, String path, File configFile) {
         section.set(path + ".x", value.x());
         section.set(path + ".z", value.z());
+
+        save(configFile);
     }
 
     @Override

--- a/src/main/java/dev/crafty/core/geometry/serializers/Point2dSerializer.java
+++ b/src/main/java/dev/crafty/core/geometry/serializers/Point2dSerializer.java
@@ -22,11 +22,15 @@ public class Point2dSerializer implements ConfigSerializer<Point2d> {
      * @param configFile The configuration file to save changes to.
      */
     @Override
-    public void serialize(Point2d value, SectionWrapper section, String path, File configFile) {
+    public void serialize(SerializationArgs<Point2d> args) {
+        var section = args.section();
+        var path = args.path();
+        var value = args.value();
+
         section.set(path + ".x", value.x());
         section.set(path + ".z", value.z());
 
-        save(configFile);
+        save(args);
     }
 
     @Override

--- a/src/main/java/dev/crafty/core/geometry/serializers/Point2dSerializer.java
+++ b/src/main/java/dev/crafty/core/geometry/serializers/Point2dSerializer.java
@@ -13,6 +13,14 @@ import java.util.concurrent.atomic.AtomicReference;
  * @since 1.0.3
  */
 public class Point2dSerializer implements ConfigSerializer<Point2d> {
+    /**
+     * Serializes a Point2d object into the given configuration section at the specified path.
+     *
+     * @param value      The Point2d object to serialize.
+     * @param section    The configuration section where the data will be stored.
+     * @param path       The path within the section to store the Point2d data.
+     * @param configFile The configuration file to save changes to.
+     */
     @Override
     public void serialize(Point2d value, SectionWrapper section, String path, File configFile) {
         section.set(path + ".x", value.x());

--- a/src/main/java/dev/crafty/core/geometry/serializers/Polygon3dSerializer.java
+++ b/src/main/java/dev/crafty/core/geometry/serializers/Polygon3dSerializer.java
@@ -29,7 +29,7 @@ public class Polygon3dSerializer implements ConfigSerializer<Polygon3d> {
 
         for (int i = 1; i <= points.size(); i++) {
             Point2d point = points.get(i - 1);
-            SerializationArgs<Point2d> pointArgs = new SerializationArgs<>(point, verticesSection, i + "", args.configFile(), false);
+            SerializationArgs<Point2d> pointArgs = new SerializationArgs<>(point, verticesSection, args.parent(), i + "", args.configFile(), false);
             getSerializer(Point2d.class).serialize(pointArgs);
         }
 

--- a/src/main/java/dev/crafty/core/geometry/serializers/Polygon3dSerializer.java
+++ b/src/main/java/dev/crafty/core/geometry/serializers/Polygon3dSerializer.java
@@ -5,6 +5,7 @@ import dev.crafty.core.config.serializer.ConfigSerializer;
 import dev.crafty.core.geometry.Point2d;
 import dev.crafty.core.geometry.polygons.Polygon3d;
 
+import java.io.File;
 import java.util.List;
 import java.util.Optional;
 
@@ -13,7 +14,7 @@ import java.util.Optional;
  */
 public class Polygon3dSerializer implements ConfigSerializer<Polygon3d> {
     @Override
-    public void serialize(Polygon3d value, SectionWrapper section, String path) {
+    public void serialize(Polygon3d value, SectionWrapper section, String path, File configFile) {
         List<Point2d> points = value.getVertices();
         double minY = value.getMinY();
         double maxY = value.getMaxY();
@@ -25,8 +26,10 @@ public class Polygon3dSerializer implements ConfigSerializer<Polygon3d> {
 
         for (int i = 1; i <= points.size(); i++) {
             Point2d point = points.get(i - 1);
-            getSerializer(Point2d.class).serialize(point, verticesSection, i + "");
+            getSerializer(Point2d.class).serialize(point, verticesSection, i + "", configFile);
         }
+
+        save(configFile);
     }
 
     @Override

--- a/src/main/java/dev/crafty/core/geometry/serializers/Polygon3dSerializer.java
+++ b/src/main/java/dev/crafty/core/geometry/serializers/Polygon3dSerializer.java
@@ -5,7 +5,6 @@ import dev.crafty.core.config.serializer.ConfigSerializer;
 import dev.crafty.core.geometry.Point2d;
 import dev.crafty.core.geometry.polygons.Polygon3d;
 
-import java.io.File;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,7 +13,11 @@ import java.util.Optional;
  */
 public class Polygon3dSerializer implements ConfigSerializer<Polygon3d> {
     @Override
-    public void serialize(Polygon3d value, SectionWrapper section, String path, File configFile) {
+    public void serialize(SerializationArgs<Polygon3d> args) {
+        var section = args.section();
+        var path = args.path();
+        var value = args.value();
+
         List<Point2d> points = value.getVertices();
         double minY = value.getMinY();
         double maxY = value.getMaxY();
@@ -26,10 +29,11 @@ public class Polygon3dSerializer implements ConfigSerializer<Polygon3d> {
 
         for (int i = 1; i <= points.size(); i++) {
             Point2d point = points.get(i - 1);
-            getSerializer(Point2d.class).serialize(point, verticesSection, i + "", configFile);
+            SerializationArgs<Point2d> pointArgs = new SerializationArgs<>(point, verticesSection, i + "", args.configFile(), false);
+            getSerializer(Point2d.class).serialize(pointArgs);
         }
 
-        save(configFile);
+        save(args);
     }
 
     @Override

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: CraftyCore
-version: '1.0.3'
+version: '1.0.6'
 main: dev.crafty.core.CraftyCore
 api-version: '1.21'


### PR DESCRIPTION
## Summary by Sourcery

Enable automatic persistence of configuration files by refactoring serializers and configuration management to save changes to disk.

New Features:
- Persist configuration changes to YAML files immediately upon serialization.

Enhancements:
- Use YamlConfiguration directly in ConfigurationManager cache and return types.
- Extend ConfigSerializer.serialize() signature to include the File parameter and add a default save(File) helper.
- Update populateObject and reloadObject methods to write updated config files after populating fields.
- Modify factory and built-in serializers (simple, list, Polygon3d, ItemStack, Point2d) to invoke save(configFile) after setting values.