### PR TITLE
Add CachedConfigObject for file-backed cached configurations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.crafty</groupId>
     <artifactId>craftycore</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <packaging>jar</packaging>
 
     <name>CraftyCore</name>

--- a/src/main/java/dev/crafty/core/CraftyCore.java
+++ b/src/main/java/dev/crafty/core/CraftyCore.java
@@ -1,5 +1,6 @@
 package dev.crafty.core;
 
+import dev.crafty.core.bukkit.CraftyLogger;
 import dev.crafty.core.config.ConfigurationUtils;
 import dev.crafty.core.config.ConfigWatcher;
 import dev.crafty.core.config.SectionWrapper;
@@ -7,6 +8,7 @@ import dev.crafty.core.i18n.i18nManager;
 import dev.crafty.core.storage.ProviderManager;
 import dev.crafty.core.storage.StorageProvider;
 import dev.crafty.core.storage.StorageProviderFactory;
+import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.plugin.Plugin;
@@ -27,10 +29,20 @@ public final class CraftyCore extends JavaPlugin {
 
     private final Map<String, List<Object>> registeredConfigs = new HashMap<>();
     private ConfigWatcher configWatcher;
+    /**
+     * -- GETTER --
+     *  Check if the configuration watcher is enabled.
+     *
+     * @return True if the watcher is enabled, false otherwise
+     */
+    @Getter
     private boolean configWatcherEnabled = true;
+
+    public CraftyLogger logger;
 
     @Override
     public void onEnable() {
+        logger = new CraftyLogger(this);
         INSTANCE = this;
 
         // Save default config
@@ -45,7 +57,7 @@ public final class CraftyCore extends JavaPlugin {
             setupConfigWatcher();
         }
 
-        getLogger().info("CraftyCore has been enabled!");
+        logger.info("CraftyCore has been enabled!");
     }
 
     @Override
@@ -81,8 +93,8 @@ public final class CraftyCore extends JavaPlugin {
         // Then reload all registered configurations
         int reloadedCount = ConfigurationUtils.reloadAllConfigs(plugin);
 
-        getLogger().info("Scanned and found " + scannedCount + " configuration classes for " + plugin.getName());
-        getLogger().info("Reloaded " + reloadedCount + " configurations for " + plugin.getName());
+        logger.info("Scanned and found " + scannedCount + " configuration classes for " + plugin.getName());
+        logger.info("Reloaded " + reloadedCount + " configurations for " + plugin.getName());
 
         return reloadedCount;
     }
@@ -94,7 +106,7 @@ public final class CraftyCore extends JavaPlugin {
             configWatcher.stop();
         }
 
-        getLogger().info("CraftyCore has been disabled!");
+        logger.info("CraftyCore has been disabled!");
     }
 
     /**
@@ -115,22 +127,13 @@ public final class CraftyCore extends JavaPlugin {
     }
 
     /**
-     * Check if the configuration watcher is enabled.
-     * 
-     * @return True if the watcher is enabled, false otherwise
-     */
-    public boolean isConfigWatcherEnabled() {
-        return configWatcherEnabled;
-    }
-
-    /**
      * Set up a file watcher to monitor changes to the config.yml file
      * and automatically reload the configuration when changes are detected.
      */
     private void setupConfigWatcher() {
         // Create a config watcher for the plugin's config.yml file
         configWatcher = ConfigWatcher.forPluginConfig(this, () -> {
-            getLogger().info("Detected changes to config.yml, reloading configuration...");
+            logger.info("Detected changes to config.yml, reloading configuration...");
             reloadConfig();
             onConfigReloaded();
         });
@@ -147,7 +150,7 @@ public final class CraftyCore extends JavaPlugin {
     public void onConfigReloaded() {
         // Reload all registered configurations
         scanAndReloadConfigs(this);
-        getLogger().info("CraftyCore configuration reloaded");
+        logger.info("CraftyCore configuration reloaded");
     }
 
     /**
@@ -162,7 +165,7 @@ public final class CraftyCore extends JavaPlugin {
             registeredConfigs.put(pluginName, new ArrayList<>());
         }
         registeredConfigs.get(pluginName).add(configObject);
-        getLogger().info("Registered configuration for " + plugin.getName());
+        logger.info("Registered configuration for " + plugin.getName());
     }
 
     /**
@@ -187,7 +190,7 @@ public final class CraftyCore extends JavaPlugin {
         Plugin targetPlugin = Bukkit.getPluginManager().getPlugin(pluginName);
 
         if (targetPlugin == null) {
-            getLogger().warning("Could not find plugin: " + pluginName);
+            logger.warn("Could not find plugin: " + pluginName);
             return false;
         }
 
@@ -212,7 +215,7 @@ public final class CraftyCore extends JavaPlugin {
             }
         }
 
-        getLogger().info("Reloaded " + totalCount + " configurations for all plugins");
+        logger.info("Reloaded " + totalCount + " configurations for all plugins");
     }
 
     /**

--- a/src/main/java/dev/crafty/core/CraftyCore.java
+++ b/src/main/java/dev/crafty/core/CraftyCore.java
@@ -29,12 +29,7 @@ public final class CraftyCore extends JavaPlugin {
 
     private final Map<String, List<Object>> registeredConfigs = new HashMap<>();
     private ConfigWatcher configWatcher;
-    /**
-     * -- GETTER --
-     *  Check if the configuration watcher is enabled.
-     *
-     * @return True if the watcher is enabled, false otherwise
-     */
+
     @Getter
     private boolean configWatcherEnabled = true;
 

--- a/src/main/java/dev/crafty/core/CraftyCore.java
+++ b/src/main/java/dev/crafty/core/CraftyCore.java
@@ -4,17 +4,13 @@ import dev.crafty.core.bukkit.CraftyLogger;
 import dev.crafty.core.config.ConfigurationUtils;
 import dev.crafty.core.config.ConfigWatcher;
 import dev.crafty.core.config.SectionWrapper;
-import dev.crafty.core.i18n.i18nManager;
 import dev.crafty.core.storage.ProviderManager;
-import dev.crafty.core.storage.StorageProvider;
 import dev.crafty.core.storage.StorageProviderFactory;
 import lombok.Getter;
 import org.bukkit.Bukkit;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.io.File;
 import java.nio.file.Path;
 import java.util.*;
 

--- a/src/main/java/dev/crafty/core/config/CachedConfigObject.java
+++ b/src/main/java/dev/crafty/core/config/CachedConfigObject.java
@@ -1,0 +1,262 @@
+package dev.crafty.core.config;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import dev.crafty.core.CraftyCore;
+import dev.crafty.core.config.serializer.ConfigSerializer;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * An abstract class that provides a cached, file-backed configuration object.
+ *
+ * <p>
+ * This class uses a Caffeine cache to store objects in memory and synchronizes them
+ * with a YAML configuration file on disk. Subclasses or instances (via the Builder)
+ * must provide the config file, serializer, and config section.
+ * </p>
+ *
+ * @param <K> the type of the key used to identify objects
+ * @param <V> the type of the value to be cached and serialized
+ *
+ * @since 1.0.5
+ */
+public abstract class CachedConfigObject<K, V> {
+    private final Cache<K, V> cache = Caffeine.newBuilder().build();
+
+    /**
+     * Returns the configuration file backing this cache.
+     *
+     * @return the config file
+     */
+    protected abstract File getConfigFile();
+
+    /**
+     * Returns the serializer used to (de)serialize objects to/from the config.
+     *
+     * @return an optional serializer
+     */
+    protected abstract Optional<ConfigSerializer<V>> getSerializer();
+
+    /**
+     * Returns the section name in the config file where objects are stored.
+     *
+     * @return the config section name
+     */
+    protected abstract String getConfigSection();
+
+    /**
+     * Gets a value from the cache, loading from config if not present.
+     *
+     * @param key the key to look up
+     * @return an optional containing the value if present
+     */
+    public Optional<V> get(K key) {
+        return Optional.ofNullable(cache.get(key, k -> {
+            Optional<V> value = getFromConfig(k);
+            return value.orElse(null);
+        }));
+    }
+
+    /**
+     * Loads all values from the config section into the cache, replacing any existing cache entries.
+     */
+    public void loadAll() {
+        cache.invalidateAll();
+        Optional<File> fileOpt = ensureFileExists();
+        if (fileOpt.isEmpty()) {
+            return;
+        }
+
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(fileOpt.get());
+        ConfigurationSection section = config.getConfigurationSection(getConfigSection());
+
+        if (section == null) {
+            return;
+        }
+
+        for (String key : section.getKeys(false)) {
+            Optional<V> value = getFromConfig((K) key);
+            value.ifPresent(v -> cache.put((K) key, v));
+        }
+    }
+
+    /**
+     * Sets a value in the cache and saves it to the config file.
+     *
+     * @param key the key to set
+     * @param value the value to associate with the key
+     */
+    public void set(K key, V value) {
+        cache.put(key, value);
+        saveToConfig(key, value);
+    }
+
+    /**
+     * Saves a value to the config file.
+     *
+     * @param key the key to save
+     * @param value the value to save
+     */
+    private void saveToConfig(K key, V value) {
+        Optional<File> fileOpt = ensureFileExists();
+        if (fileOpt.isEmpty()) {
+            return;
+        }
+
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(fileOpt.get());
+        ConfigurationSection section = config.getConfigurationSection(getConfigSection());
+
+        if (section == null) {
+            config.createSection(getConfigSection());
+            section = config.getConfigurationSection(getConfigSection());
+        }
+
+        if (getSerializer().isPresent()) {
+            getSerializer().get().serialize(value, new SectionWrapper(section), getConfigSection() + "." + key);
+        }
+
+        try {
+            config.save(fileOpt.get());
+        } catch (IOException e) {
+            CraftyCore.INSTANCE.logger.error("Failed to save config file", e);
+        }
+    }
+
+    /**
+     * Ensures the config file exists, creating it if necessary.
+     *
+     * @return an optional containing the file if it exists or was created successfully
+     */
+    private Optional<File> ensureFileExists() {
+        if (!getConfigFile().exists()) {
+            try {
+                getConfigFile().createNewFile();
+            } catch (IOException e) {
+                CraftyCore.INSTANCE.logger.error("Failed to create config file", e);
+                return Optional.empty();
+            }
+        }
+        return Optional.of(getConfigFile());
+    }
+
+    /**
+     * Loads a value from the config file.
+     *
+     * @param id the key to load
+     * @return an optional containing the value if present
+     */
+    private Optional<V> getFromConfig(K id) {
+        Optional<File> fileOpt = ensureFileExists();
+        if (fileOpt.isEmpty()) {
+            return Optional.empty();
+        }
+
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(
+                fileOpt.get()
+        );
+
+        ConfigurationSection regionsSection = config.getConfigurationSection(getConfigSection());
+
+        if (regionsSection == null) {
+            config.createSection(getConfigSection());
+            try {
+                config.save(fileOpt.get());
+            } catch (IOException e) {
+                CraftyCore.INSTANCE.logger.error("Failed to save config file", e);
+                return Optional.empty();
+            }
+            return Optional.empty();
+        }
+
+        SectionWrapper section = new SectionWrapper(regionsSection);
+
+        if (!config.contains(String.valueOf(id))) {
+            return Optional.empty();
+        }
+
+        if (getSerializer().isPresent()) {
+            return getSerializer().get().deserialize(section, getConfigSection() + "." + id);
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Builder for creating instances of {@link CachedConfigObject} with custom configuration.
+     *
+     * @param <K> the type of the key
+     * @param <V> the type of the value
+     */
+    public static class Builder<K, V> {
+        private File configFile;
+        private Optional<ConfigSerializer<V>> serializer = Optional.empty();
+        private String configSection = "";
+
+        /**
+         * Sets the config file to use.
+         *
+         * @param configFile the config file
+         * @return this builder
+         */
+        public Builder<K, V> configFile(File configFile) {
+            this.configFile = configFile;
+            return this;
+        }
+
+        /**
+         * Sets the serializer to use.
+         *
+         * @param serializer the serializer
+         * @return this builder
+         */
+        public Builder<K, V> serializer(ConfigSerializer<V> serializer) {
+            this.serializer = Optional.ofNullable(serializer);
+            return this;
+        }
+
+        /**
+         * Sets the config section to use.
+         *
+         * @param configSection the config section name
+         * @return this builder
+         */
+        public Builder<K, V> configSection(String configSection) {
+            this.configSection = configSection;
+            return this;
+        }
+
+        /**
+         * Builds a new {@link CachedConfigObject} instance with the configured parameters.
+         *
+         * @return a new CachedConfigObject instance
+         */
+        public CachedConfigObject<K, V> build() {
+            final File file = this.configFile;
+            final Optional<ConfigSerializer<V>> ser = this.serializer;
+            final String section = this.configSection;
+
+            return new CachedConfigObject<>() {
+                @Override
+                protected File getConfigFile() {
+                    return file;
+                }
+
+                @Override
+                protected Optional<ConfigSerializer<V>> getSerializer() {
+                    return ser;
+                }
+
+                @Override
+                protected String getConfigSection() {
+                    return section;
+                }
+            };
+        }
+    }
+
+}

--- a/src/main/java/dev/crafty/core/config/CachedConfigObject.java
+++ b/src/main/java/dev/crafty/core/config/CachedConfigObject.java
@@ -140,7 +140,7 @@ public abstract class CachedConfigObject<K, V> {
                 getSerializer().get().serialize(
                         value,
                         new SectionWrapper(section),
-                        getConfigSection() + "." + key
+                        getConfigSection() + "." + keyToString(key)
                 );
             }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: CraftyCore
-version: '1.0.4'
+version: '1.0.5'
 main: dev.crafty.core.CraftyCore
 api-version: '1.21'


### PR DESCRIPTION
## Summary by Sourcery

Add a new cached configuration abstraction and standardize logging in the core plugin

New Features:
- Introduce an abstract CachedConfigObject class for file-backed, Caffeine-cached configurations with loading, saving, and builder support

Enhancements:
- Switch CraftyCore to initialize and use CraftyLogger instead of JavaPlugin#getLogger
- Expose configWatcherEnabled via Lombok @Getter and remove its manual getter