### PR TITLE
Fix bug where CachedConfigObject didn't use SerializationArgs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.crafty</groupId>
     <artifactId>craftycore</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
     <packaging>jar</packaging>
 
     <name>CraftyCore</name>

--- a/src/main/java/dev/crafty/core/config/CachedConfigObject.java
+++ b/src/main/java/dev/crafty/core/config/CachedConfigObject.java
@@ -137,11 +137,16 @@ public abstract class CachedConfigObject<K, V> {
             }
 
             if (getSerializer().isPresent()) {
-                getSerializer().get().serialize(
+                ConfigSerializer.SerializationArgs<V> args = new ConfigSerializer.SerializationArgs<>(
                         value,
                         new SectionWrapper(section),
-                        getConfigSection() + "." + keyToString(key)
+                        new YamlConfigurationWrapper(config),
+                        getConfigSection() + "." + keyToString(key),
+                        fileOpt.get(),
+                        true
                 );
+
+                getSerializer().get().serialize(args);
             }
 
             try {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: CraftyCore
-version: '1.0.6'
+version: '1.0.7'
 main: dev.crafty.core.CraftyCore
 api-version: '1.21'


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Use ConfigSerializer.SerializationArgs when invoking serialize in CachedConfigObject to ensure correct configuration wrapper, file, and serialization options are applied.