### PR TITLE
Add location serializer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.crafty</groupId>
     <artifactId>craftycore</artifactId>
-    <version>1.0.8</version>
+    <version>1.0.9</version>
     <packaging>jar</packaging>
 
     <name>CraftyCore</name>

--- a/src/main/java/dev/crafty/core/config/ConfigurationUtils.java
+++ b/src/main/java/dev/crafty/core/config/ConfigurationUtils.java
@@ -6,6 +6,7 @@ import dev.crafty.core.config.serializer.ConfigSerializer;
 import dev.crafty.core.config.serializer.SerializerFactory;
 import dev.crafty.core.config.serializer.SerializerRegistry;
 import dev.crafty.core.config.serializer.builtin.ItemStackSerializer;
+import dev.crafty.core.config.serializer.builtin.LocationSerializer;
 import dev.crafty.core.geometry.Point2d;
 import dev.crafty.core.geometry.polygons.Polygon3d;
 import dev.crafty.core.geometry.serializers.Point2dSerializer;
@@ -58,6 +59,7 @@ public class ConfigurationUtils {
         SerializerRegistry.register(new ItemStackSerializer());
         SerializerRegistry.register(new Point2dSerializer());
         SerializerRegistry.register(new Polygon3dSerializer());
+        SerializerRegistry.register(new LocationSerializer());
 
         plugin.getLogger().info("Configuration system initialized");
     }

--- a/src/main/java/dev/crafty/core/config/SectionWrapper.java
+++ b/src/main/java/dev/crafty/core/config/SectionWrapper.java
@@ -1,6 +1,7 @@
 package dev.crafty.core.config;
 
 import lombok.Getter;
+import org.bukkit.Location;
 import org.bukkit.configuration.ConfigurationSection;
 
 import java.util.List;
@@ -108,4 +109,7 @@ public class SectionWrapper {
         return Optional.of(delegate.getLongList(path));
     }
 
+    public Optional<Location> getLocation(String path) {
+        return Optional.ofNullable(delegate.getLocation(path));
+    }
 }

--- a/src/main/java/dev/crafty/core/config/serializer/builtin/LocationSerializer.java
+++ b/src/main/java/dev/crafty/core/config/serializer/builtin/LocationSerializer.java
@@ -1,0 +1,33 @@
+package dev.crafty.core.config.serializer.builtin;
+
+import dev.crafty.core.config.SectionWrapper;
+import dev.crafty.core.config.serializer.ConfigSerializer;
+import org.bukkit.Location;
+
+import java.util.Optional;
+
+public class LocationSerializer implements ConfigSerializer<Location> {
+    @Override
+    public void serialize(SerializationArgs<Location> args) {
+        var section = args.section();
+        var path = args.path();
+        var value = args.value();
+
+        if (value == null) {
+            section.set(path, null);
+            return;
+        }
+
+        section.set(path, value.serialize());
+    }
+
+    @Override
+    public Optional<Location> deserialize(SectionWrapper section, String path) {
+        return section.getLocation(path);
+    }
+
+    @Override
+    public Class<Location> getType() {
+        return Location.class;
+    }
+}

--- a/src/main/java/dev/crafty/core/config/serializer/builtin/LocationSerializer.java
+++ b/src/main/java/dev/crafty/core/config/serializer/builtin/LocationSerializer.java
@@ -6,6 +6,9 @@ import org.bukkit.Location;
 
 import java.util.Optional;
 
+/**
+ * @since 1.0.9
+ */
 public class LocationSerializer implements ConfigSerializer<Location> {
     @Override
     public void serialize(SerializationArgs<Location> args) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: CraftyCore
-version: '1.0.8'
+version: '1.0.9'
 main: dev.crafty.core.CraftyCore
 api-version: '1.21'


### PR DESCRIPTION
## Summary by Sourcery

Introduce support for serializing and deserializing Bukkit Location objects in the configuration system

New Features:
- Add getLocation method to SectionWrapper for fetching Location values
- Register LocationSerializer during configuration initialization
- Implement LocationSerializer to handle serialization via Location.serialize() and delegate deserialization to SectionWrapper.getLocation